### PR TITLE
Add template for remi.repo to enable specific repos by config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ None.
 
 ## Dependencies
 
-None.
+* geerlingguy.repo-epel
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+enable_remi: 0
+enable_remi_php55: 0
+enable_remi_php56: 0
+enable_remi_test: 0
+enable_remi_debuginfo: 0
+enable_remi_php55_debuginfo: 0
+enable_remi_php56_debuginfo: 0
+enable_remi_test_debuginfo: 0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
-dependencies: []
+dependencies:
+    - { role: geerlingguy.repo-epel }
 
 galaxy_info:
   author: geerlingguy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,7 @@
 
 - name: Install Remi repo.
   command: rpm -Uvh --force /tmp/remi-release-6.rpm creates=/etc/yum.repos.d/remi.repo
+
+- name: Configure Remi repo.
+  template: src=remi.repo.j2 dest=/etc/yum.repos.d/remi.repo
+  

--- a/templates/remi.repo.j2
+++ b/templates/remi.repo.j2
@@ -1,0 +1,62 @@
+[remi]
+name=Les RPM de remi pour Enterprise Linux 6 - $basearch
+#baseurl=http://rpms.famillecollet.com/enterprise/6/remi/$basearch/
+mirrorlist=http://rpms.famillecollet.com/enterprise/6/remi/mirror
+enabled={{enable_remi}}
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-php55]
+name=Les RPM de remi de PHP 5.5 pour Enterprise Linux 6 - $basearch
+#baseurl=http://rpms.famillecollet.com/enterprise/6/php55/$basearch/
+mirrorlist=http://rpms.famillecollet.com/enterprise/6/php55/mirror
+# WARNING: If you enable this repository, you must also enable "remi"
+enabled={{enable_remi_php55}}
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-php56]
+name=Les RPM de remi de PHP 5.6 pour Enterprise Linux 6 - $basearch
+#baseurl=http://rpms.famillecollet.com/enterprise/6/php56/$basearch/
+mirrorlist=http://rpms.famillecollet.com/enterprise/6/php56/mirror
+# WARNING: If you enable this repository, you must also enable "remi"
+enabled={{enable_remi_php56}}
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-test]
+name=Les RPM de remi en test pour Enterprise Linux 6 - $basearch
+#baseurl=http://rpms.famillecollet.com/enterprise/6/test/$basearch/
+mirrorlist=http://rpms.famillecollet.com/enterprise/6/test/mirror
+# WARNING: If you enable this repository, you must also enable "remi"
+enabled={{enable_remi_test}}
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-debuginfo]
+name=Les RPM de remi pour Enterprise Linux 6 - $basearch - debuginfo
+baseurl=http://rpms.famillecollet.com/enterprise/6/debug-remi/$basearch/
+enabled={{enable_remi_debuginfo}}
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-php55-debuginfo]
+name=Les RPM de remi de PHP 5.5 pour Enterprise Linux 6 - $basearch - debuginfo
+baseurl=http://rpms.famillecollet.com/enterprise/6/debug-php55/$basearch/
+enabled={{enable_remi_php55_debuginfo}}
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-php56-debuginfo]
+name=Les RPM de remi de PHP 5.6 pour Enterprise Linux 6 - $basearch - debuginfo
+baseurl=http://rpms.famillecollet.com/enterprise/6/debug-php56/$basearch/
+enabled={{enable_remi_php56_debuginfo}}
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-test-debuginfo]
+name=Les RPM de remi en test pour Enterprise Linux 6 - $basearch - debuginfo
+baseurl=http://rpms.famillecollet.com/enterprise/6/debug-test/$basearch/
+enabled={{enable_remi_test_debuginfo}}
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi


### PR DESCRIPTION
This is a approach to enable some remi repo's by config. You can enable the php56 repo to install php 5.6 with the php role for example.