### PR TITLE
Extent to fit multi version os

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+remi_repo_url: "http://rpms.famillecollet.com/enterprise/remi-release-{{ ansible_distribution_major_version }}.rpm"
+remi_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-remi"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ dependencies: []
 
 galaxy_info:
   author: geerlingguy
-  description: Remi repository for RHEL/CentOS 5-7.x.
+  description: Remi's RPM repository for RHEL/CentOS 5-7.x.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
   min_ansible_version: 1.4

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,13 +3,15 @@ dependencies: []
 
 galaxy_info:
   author: geerlingguy
-  description: Remi repository for RHEL/CentOS 6.x.
+  description: Remi repository for RHEL/CentOS 5-7.x.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
   min_ansible_version: 1.4
   platforms:
   - name: EL
     versions:
+    - 5
     - 6
+    - 7
   categories:
     - packaging

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
 # Remi yum repository.
-- name: Download Remi repo.
-  get_url: url=http://rpms.famillecollet.com/enterprise/remi-release-6.rpm dest=/tmp/
+- name: Install remi repo.
+  yum: 
+    name: "{{ remi_repo_url }}"
+    state: present
 
-- name: Install Remi repo.
-  command: rpm -Uvh --force /tmp/remi-release-6.rpm creates=/etc/yum.repos.d/remi.repo
+- name: Import remi GPG key.
+  rpm_key:
+    key: "{{ remi_repo_gpg_key_url }}"
+    state: present


### PR DESCRIPTION
ansible-role-remi is fixed remi's RPM repository version 6.
It is make some troubles to use CentOS 7(but not seriously).

Changed to fit multiple the versions for CentOS 5,6,7 
This code is transfered from ansible-role-repo-epel.

