### PR TITLE
Make role work on EL4, EL5 and EL7 as well

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Remi yum repository.
 - name: Download Remi repo.
-  get_url: url=http://rpms.famillecollet.com/enterprise/remi-release-6.rpm dest=/tmp/
+  get_url: url=http://rpms.famillecollet.com/enterprise/remi-release-{{ ansible_distribution_major_version }}.rpm dest=/tmp/
 
 - name: Install Remi repo.
-  command: rpm -Uvh --force /tmp/remi-release-6.rpm creates=/etc/yum.repos.d/remi.repo
+  command: rpm -Uvh --force /tmp/remi-release-{{ ansible_distribution_major_version }}.rpm creates=/etc/yum.repos.d/remi.repo


### PR DESCRIPTION
This PR uses `ansible_distribution_major_version` to install the correct RPM. 
This is similar to [geerlingguy/ansible-role-repo-epel](https://github.com/geerlingguy/ansible-role-repo-epel).