### PR TITLE
Use HTTPS for remi repos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-remi_repo_url: "http://rpms.remirepo.net/enterprise/remi-release-{{ ansible_distribution_major_version }}.rpm"
-remi_repo_gpg_key_url: "http://rpms.remirepo.net/RPM-GPG-KEY-remi"
+remi_repo_url: "https://rpms.remirepo.net/enterprise/remi-release-{{ ansible_distribution_major_version }}.rpm"
+remi_repo_gpg_key_url: "https://rpms.remirepo.net/RPM-GPG-KEY-remi"


### PR DESCRIPTION
Just ran into an issue with this role in a firewalled network. It was blocking the `yum` user-agent of "urlgrabber/3.10 yum/3.4.3" (only in combination with the unsecured remi URL though) with a 503 and identifying it as `App-ID: yum`. Changing to HTTPS got past the block and returned a 200.