### PR TITLE
Ansible 2.9.13 compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: Install remi repo.
-  yum:
-    name: "{{ remi_repo_url }}"
-    state: present
-
 - name: Import remi GPG key.
   rpm_key:
     key: "{{ remi_repo_gpg_key_url }}"
+    state: present
+
+- name: Install remi repo.
+  yum:
+    name: "{{ remi_repo_url }}"
     state: present


### PR DESCRIPTION
Ansible 2.9.13 fixed a security bug with the yum/dnf module, as package signature were not checked. https://github.com/ansible/ansible/pull/71537

The rpm keys need to be imported before the repository is installed. The only reason it did not fail before was because those keys were not checked.

**Also** just swaping out the order of tasks is not enough, as the Remi repository has different rpm keys for different *years* now, it seems. https://blog.remirepo.net/pages/Config-en (see **4. Remi's signature Installation (GPG Key)**).

This can be worked around with the `remi_repo_gpg_key_url` variable, but I would suggest to change this role to import them all, and allow them to be overwritten as well. Let's say by changing it to `remo_repo_gpg_key_url**s**`

Reference of upstream issue of this bug https://github.com/ansible/ansible/issues/71634