### PR TITLE
Added rpm key for Centos 8 and import key before install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 remi_repo_url: "http://rpms.remirepo.net/enterprise/remi-release-{{ ansible_distribution_major_version }}.rpm"
-remi_repo_gpg_key_url: "http://rpms.remirepo.net/RPM-GPG-KEY-remi"
+remi_repo_gpg_key_url: "https://rpms.remirepo.net/RPM-GPG-KEY-remi2018"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 remi_repo_url: "http://rpms.remirepo.net/enterprise/remi-release-{{ ansible_distribution_major_version }}.rpm"
-remi_repo_gpg_key_url: "https://rpms.remirepo.net/RPM-GPG-KEY-remi2018"
+remi_repo_gpg_key_url: "{{ 'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018' if (ansible_distribution_major_version == '8') else 'https://rpms.remirepo.net/RPM-GPG-KEY-remi' }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: Install remi repo.
-  yum:
-    name: "{{ remi_repo_url }}"
-    state: present
-
 - name: Import remi GPG key.
   rpm_key:
     key: "{{ remi_repo_gpg_key_url }}"
+    state: present
+
+- name: Install remi repo.
+  yum:
+    name: "{{ remi_repo_url }}"
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,12 @@
 ---
+- name: Import remi GPG key.
+  rpm_key:
+    key: "{{ remi_repo_gpg_key_url }}"
+    state: present
+
 - name: Install remi repo.
   yum:
     name: "{{ remi_repo_url }}"
     state: present
 
-- name: Import remi GPG key.
-  rpm_key:
-    key: "{{ remi_repo_gpg_key_url }}"
-    state: present
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
-- name: Import remi GPG key.
-  rpm_key:
-    key: "{{ remi_repo_gpg_key_url }}"
-    state: present
-
 - name: Install remi repo.
   yum:
     name: "{{ remi_repo_url }}"
     state: present
 
-
+- name: Import remi GPG key.
+  rpm_key:
+    key: "{{ remi_repo_gpg_key_url }}"
+    state: present


### PR DESCRIPTION
Added a conditional to import the rpm key for Centos 8 and reversed the order so that the key gets imported before an install is attempted.