### PR TITLE
execute only if os_family == RedHat

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,13 @@
 ---
-- name: Import remi GPG key.
-  rpm_key:
-    key: "{{ remi_repo_gpg_key_url }}"
-    state: present
+- block:
+  - name: Import remi GPG key.
+    rpm_key:
+      key: "{{ remi_repo_gpg_key_url }}"
+      state: present
 
-- name: Install remi repo.
-  yum:
-    name: "{{ remi_repo_url }}"
-    state: present
+  - name: Install remi repo.
+    yum:
+      name: "{{ remi_repo_url }}"
+      state: present
+
+  when: ansible_os_family == "RedHat"


### PR DESCRIPTION
This Role is only for RedHat.
The play failed if you have RedHat and no RedHat systems in your ansible-group.
With this PR, the role skip all no RedHat systems