### PR TITLE
Changing Remi's GPG Key to work in RHEL9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 remi_repo_url: "https://rpms.remirepo.net/enterprise/remi-release-{{ ansible_distribution_major_version }}.rpm"
-remi_repo_gpg_key_url: "https://rpms.remirepo.net/RPM-GPG-KEY-remi2018"
+remi_repo_gpg_key_url: "https://rpms.remirepo.net/RPM-GPG-KEY-remi2021"


### PR DESCRIPTION
While using the role at RHEL8, everything worked fine. After updating to RHEL9, I started receiving a fatal error due the GPG key. ("Failed to validate GPG signature for remi-release-9.0-6.el9.remi.noarch")

As Remi's RPM Repository says, "RPM-GPG-KEY-remi2021: the GnuPG public key of the key pair used to sign my packages (Fedora 34-35 and EL-9)"